### PR TITLE
Fix HTML head injection and button scaling

### DIFF
--- a/src/html.js
+++ b/src/html.js
@@ -3,13 +3,18 @@ import React from "react"
 export default function HTML(props) {
   return (
     <html {...props.htmlAttributes}>
-      <head {...props.headComponents}>
+      <head>
         {/* Tailwind CDN */}
         <link href="https://cdn.tailwindcss.com" rel="stylesheet" />
-        {props.preBodyComponents}
+        {props.headComponents}
       </head>
       <body {...props.bodyAttributes}>
-        {props.body}
+        {props.preBodyComponents}
+        <div
+          key="body"
+          id="___gatsby"
+          dangerouslySetInnerHTML={{ __html: props.body }}
+        />
         {props.postBodyComponents}
       </body>
     </html>

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -106,7 +106,7 @@ const IndexPage = () => {
 
           {/* View All Projects Button */}
           <div className="text-center mt-12">
-            <button className="bg-purple-600 hover:bg-purple-700 text-white px-8 py-4 rounded-full font-semibold text-lg transition-all duration-300 hover-scale shadow-lg">
+            <button className="bg-purple-600 hover:bg-purple-700 text-white px-8 py-4 rounded-full font-semibold text-lg transition-all duration-300 transform hover:scale-105 shadow-lg">
               View All Projects
               <svg className="inline-block w-5 h-5 ml-2" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                 <path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M17 8l4 4m0 0l-4 4m4-4H3" />


### PR DESCRIPTION
## Summary
- fix the custom html wrapper so Gatsby inserts head and body components correctly
- correct Tailwind button scaling class on the index page

## Testing
- `npm test` *(fails: Write tests! -> https://gatsby.dev/unit-testing)*

------
https://chatgpt.com/codex/tasks/task_e_6846b8fe18608322bd0db5e6d1f531c1